### PR TITLE
Use maven central portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022-2023, FusionAuth, All Rights Reserved
+  ~ Copyright (c) 2022-2025, FusionAuth, All Rights Reserved
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -30,13 +30,16 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
   </distributionManagement>
 
   <developers>
@@ -116,14 +119,12 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.13</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
             </configuration>
           </plugin>
           <plugin>


### PR DESCRIPTION
### Summary
Update the `pom.xml` to use Maven Central Portal. 

### TL;DR
As far as I know there isn't a way to fully test this ahead of a release. 

Here is the release plugin doc:
- https://central.sonatype.org/publish/publish-portal-maven/

There is a `skipPublishing` property, but all that does is a local bundle, it won’t test the credentials.

I ran into this publishing issue when publishing `java-http` because the old publishing server OSSRH is now sunset.

But I did make this same change to `java-http` and published successfully.  So I know it works for another repo with the same config.
- https://github.com/FusionAuth/java-http/commit/8494f2e312ebbfc711d1162c8b7d015bfeb66a29

Based upon `java-http` I am confident this is the correct config - the only other variable is ensuring we get the updated credentials into GHA secrets manager and ensuring the release GHA runner is built using the updated version of `fusionauth-developer`.

The only difference at release time will be for `fusionauth-java-client` we use a GHA runner which will use GHA secrets manager. I have updated `fusionauth-developer` to get the correct settings into the `setting.xml` and updated the 1Password entry for the new creds for the platform account and let John know to update GHA secrets manager. 

### Related
- https://github.com/FusionAuth/fusionauth-java-client/pull/116
- https://github.com/fusionauth-eng/fusionauth-developer/pull/50